### PR TITLE
fix odbc driver version for sql server

### DIFF
--- a/scripts/install-mssql.sh
+++ b/scripts/install-mssql.sh
@@ -14,8 +14,12 @@ curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
-sudo apt-get install -y unixodbc-dev
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql=13.0.1.0-1 mssql-tools=14.0.2.0-1
+sudo apt-get install -y unixodbc-dev-utf16
+
+# Create symlinks for tools
+ln -sfn /opt/mssql-tools/bin/sqlcmd-13.0.1.0 /usr/bin/sqlcmd 
+ln -sfn /opt/mssql-tools/bin/bcp-13.0.1.0 /usr/bin/bcp
 
 # Install the Microsoft PHP Drivers for SQL Server
 sudo pecl install sqlsrv


### PR DESCRIPTION
Today I noticed that after destroying my vagrant VM and setting it up again, the sql server connection did not work anymore and showed the error:
```
[Illuminate\Database\QueryException]
SQLSTATE[IMSSP]: This extension requires the Microsoft ODBC Driver 13 for SQL Server 
to communicate with SQL Server. Access the following URL to download the 
ODBC Driver 13 for SQL Server for x64: http://go.microsoft.com/fwlink/?LinkId=163712 
(SQL: select * from sysobjects where type = 'U' and name = migrations)

[Doctrine\DBAL\Driver\PDOException]
SQLSTATE[IMSSP]: This extension requires the Microsoft ODBC Driver 13 for SQL Server 
to communicate with SQL Server. Access the following URL to download the 
ODBC Driver 13 for SQL Server for x64: http://go.microsoft.com/fwlink/?LinkId=163712

[PDOException]
SQLSTATE[IMSSP]: This extension requires the Microsoft ODBC Driver 13 for SQL Server 
to communicate with SQL Server. Access the following URL to download the 
ODBC Driver 13 for SQL Server for x64: http://go.microsoft.com/fwlink/?LinkId=163712
```

After some research and with the help of the [Microsoft Documentation for the ODBC Driver for SQL Server](https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server), I figured out that with `sudo ACCEPT_EULA=Y apt-get install -y msodbcsql=13.0.1.0-1 mssql-tools=14.0.2.0-1 --allow-downgrades`, it started working again. Therefore I guess that installing this versions instead of the other ones in the first place, should solve the issue. Hopefully this helps someone else as well. The installation script is taken from the documentation.

This PR prevents the `install-mssql.sh` script from installing the `Microsoft ODBC Driver for SQL Server` in version `13.1`. It forces version `13.0`.